### PR TITLE
Send user to the mobile sign in page

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,7 +61,7 @@ function submit(e) {
 
 function getUrl(handle) {
     var splitted = handle.split('@');
-    return 'https://' + splitted[1] + '/users/sign_in?user[username]=' + splitted[0];
+    return 'https://' + splitted[1] + '/users/sign_in.mobile?user[username]=' + splitted[0];
 }
 
 function deleteHandle(event) {


### PR DESCRIPTION
Fixes #16

Some users have a mobile device with a resolution large enough for diaspora to render the desktop view although it is not easily readable.
This loads the mobile sign in which in turn forces the mobile view.